### PR TITLE
[RSN-58] - Split status enum into two seperate ones

### DIFF
--- a/Database/init-constraints.sql
+++ b/Database/init-constraints.sql
@@ -45,10 +45,6 @@ ALTER TABLE events.parameter ADD CONSTRAINT chk_parameter_value CHECK (value ~ '
 
 ALTER TABLE events.parameter ADD CONSTRAINT chk_parameter_key CHECK (key ~ '^[[:alpha:]]+(?:\s[[:alpha:]]+)*$');
 
-ALTER TABLE events.event ADD CONSTRAINT chk_event_status CHECK (status in ('Completed', 'In progress', 'Waiting for approval'));
-
-ALTER TABLE events.participant ADD CONSTRAINT chk_participant_status CHECK (status in ('Interested', 'Participating'));
-
 CREATE UNIQUE INDEX unique_image_for_user
 ON common.image ("object_type", "object_id")
 WHERE ("object_type" = 'User');

--- a/Database/init-db.sql
+++ b/Database/init-db.sql
@@ -2,7 +2,8 @@ CREATE SCHEMA events;
 CREATE SCHEMA users;
 CREATE SCHEMA common;
 
-CREATE TYPE common.status AS ENUM ('Interested', 'Participating', 'Completed', 'In progress', 'Waiting for approval');
+CREATE TYPE common.participant_status AS ENUM ('Interested', 'Participating');
+CREATE TYPE common.event_status AS ENUM ('Completed', 'In progress', 'Approved', 'Waiting for approval');
 CREATE TYPE users.role AS ENUM ('User', 'Organizer', 'Admin');
 CREATE TYPE common.object_type AS ENUM ('Event', 'User');
 
@@ -17,14 +18,14 @@ CREATE TABLE IF NOT EXISTS events.event (
   "created_at" timestamptz NOT NULL,
   "updated_at" timestamptz NOT NULL,
   "slug" text NOT NULL CONSTRAINT events_event_slug_maxlength CHECK (LENGTH("slug") <= 128),
-  "status" common.status NOT NULL
+  "status" common.event_status NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS events.participant (
   "id" SERIAL PRIMARY KEY,
   "event_id" integer NOT NULL,
   "user_id" integer NOT NULL,
-  "status" common.status NOT NULL,
+  "status" common.participant_status NOT NULL,
   UNIQUE ("event_id", "user_id")
 );
 

--- a/Database/init-dev-data.sql
+++ b/Database/init-dev-data.sql
@@ -25,7 +25,7 @@ INSERT INTO users.user ("id", "name", "surname", "username", "password", "create
 SELECT setval('users.user_id_seq', (SELECT MAX(id) FROM users.user));
 
 INSERT INTO events.event ("id", "name", "address_id", "description", "organizer_id", "start_at", "end_at", "created_at", "updated_at", "slug", "status") VALUES
-(1, 'Tech Conference', 1, 'Annual tech conference', 1, '2023-10-01 09:00:00', '2023-10-02 17:00:00', '2023-09-01 08:00:00', '2023-09-01 08:00:00', 'tech-conference', 'Completed'),
+(1, 'Tech Conference', 1, 'Annual tech conference', 1, '2023-10-01 09:00:00', '2023-10-02 17:00:00', '2023-09-01 08:00:00', '2023-09-01 08:00:00', 'tech-conference', 'Approved'),
 (2, 'Health Symposium', 2, 'Health and wellness symposium', 2, '2023-11-05 09:00:00', '2023-11-06 17:00:00', '2023-10-05 08:00:00', '2023-10-05 08:00:00', 'health-symposium', 'In progress'),
 (3, 'Koncert Rockowy', 3, 'Występ ulubionych zespołów rockowych', 2, CURRENT_TIMESTAMP - '1 day'::INTERVAL, CURRENT_TIMESTAMP + '4 hours'::INTERVAL, '2023-09-01 08:00:00', '2023-09-01 08:00:00', 'koncert-rockowy', 'Waiting for approval'),
 (4, 'Konferencja IT', 4, 'Coroczna konferencja technologiczna', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + '3 hours'::INTERVAL, '2023-10-02 17:00:00', '2023-10-02 18:00:00', 'konferencja-it', 'Completed'),


### PR DESCRIPTION
## Description
Split enums into seperate ones for event and for participant

## Related issue and/or ticket
Closes #37
RSN-58
