### PR TITLE
[RSN-26] Change regexes to match more correct formats

### DIFF
--- a/Database/init-constraints.sql
+++ b/Database/init-constraints.sql
@@ -29,7 +29,7 @@ ALTER TABLE users.user ADD CONSTRAINT chk_user_phone CHECK (phone ~ '^\+\d{1,3}\
 
 ALTER TABLE users.user ADD CONSTRAINT chk_user_name CHECK (name ~ '^[[:upper:]][[:alpha:]\s''-]+$');
 
-ALTER TABLE users.user ADD CONSTRAINT chk_user_surname CHECK (surname ~ '^[[:alpha:]\s''-]*[^\s''-]+[[:alpha:]\s''-]*$');
+ALTER TABLE users.user ADD CONSTRAINT chk_user_surname CHECK (surname ~ '^[[:alpha:]]+(?:[\s''-][[:alpha:]]+)*$');
 
 ALTER TABLE users.user ADD CONSTRAINT chk_user_username CHECK (username ~ '^[[:alnum:]_-]{4,}$');
 

--- a/Database/init-constraints.sql
+++ b/Database/init-constraints.sql
@@ -13,25 +13,25 @@ $$ LANGUAGE plpgsql STABLE;
 ALTER TABLE common.image ADD CONSTRAINT chk_object_fk
 CHECK (common.check_fk_exists(object_id, object_type));
 
-ALTER TABLE common.address ADD CONSTRAINT chk_address_street CHECK (street ~ '^[[:alnum:]]+(?:(\s)[[:alpha:]]+)*(\s(?:(\d+|\d+/\d+)))?$');
+ALTER TABLE common.address ADD CONSTRAINT chk_address_street CHECK (street ~ '^[[:alnum:]\s\-/.,#'']+(?<![-\s#,])$');
 
 ALTER TABLE common.address ADD CONSTRAINT chk_address_zip_code CHECK (zip_code ~ '^[[:alnum:]\s-]{3,}$');
 
-ALTER TABLE common.address ADD CONSTRAINT chk_address_city CHECK (city ~ '^[[:upper:]][[:lower:]]+(?:(\s|-)[[:upper:]][[:lower:]]+)*$');
+ALTER TABLE common.address ADD CONSTRAINT chk_address_city CHECK (city ~ '^[[:upper:]][[:lower:]''.]+(?:[\s-][[:alpha:]''.]+)*$');
 
 ALTER TABLE common.address ADD CONSTRAINT chk_address_state CHECK (state ~ '^[[:upper:]][[:lower:]]+(?:(\s|-)[[:alpha:]]+)*$');
 
 ALTER TABLE common.address ADD CONSTRAINT chk_address_country CHECK (country ~ '^[[:upper:]][[:lower:]]+(?:\s[[:upper:]][[:lower:]]+){0,1}$');
 
-ALTER TABLE users.user  ADD CONSTRAINT chk_user_email CHECK (email ~ '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6}$');
+ALTER TABLE users.user ADD CONSTRAINT chk_user_email CHECK (email ~ '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6}$');
 
 ALTER TABLE users.user ADD CONSTRAINT chk_user_phone CHECK (phone ~ '^\+\d{1,3}\s\d{1,15}$');
 
-ALTER TABLE users.user ADD CONSTRAINT chk_user_name CHECK (name ~ '^[[:upper:]][[:lower:]]+$');
+ALTER TABLE users.user ADD CONSTRAINT chk_user_name CHECK (name ~ '^[[:upper:]][[:alpha:]\s''-]+$');
 
-ALTER TABLE users.user ADD CONSTRAINT chk_user_surname CHECK (surname ~ '^[[:alpha:]]+((\s)?('')?(-)?)?[[:alpha:]]+$');
+ALTER TABLE users.user ADD CONSTRAINT chk_user_surname CHECK (surname ~ '^[[:alpha:]\s''-]*[^\s''-]+[[:alpha:]\s''-]*$');
 
-ALTER TABLE users.user ADD CONSTRAINT chk_user_username CHECK (username ~ '^[[:alnum:]]+$');
+ALTER TABLE users.user ADD CONSTRAINT chk_user_username CHECK (username ~ '^[[:alnum:]_-]{4,}$');
 
 ALTER TABLE users.interest ADD CONSTRAINT chk_interest_name CHECK (name ~ '^[[:upper:]][[:lower:]]+(?:\s[[:alpha:]]+)*$');
 

--- a/Database/init-constraints.sql
+++ b/Database/init-constraints.sql
@@ -2,7 +2,7 @@ CREATE OR REPLACE FUNCTION
 common.check_fk_exists(object_id INT, object_type common.object_type)
 RETURNS BOOLEAN AS $$
 BEGIN
-	IF object_type = 'User' THEN
+    IF object_type = 'User' THEN
 	RETURN EXISTS (SELECT 1 FROM users.user WHERE "id" = object_id);
 	ELSIF object_type = 'Event' THEN RETURN EXISTS (SELECT 1 FROM events.event WHERE "id" = object_id);
 	ELSE RETURN FALSE;
@@ -21,7 +21,7 @@ ALTER TABLE common.address ADD CONSTRAINT chk_address_city CHECK (city ~ '^[[:up
 
 ALTER TABLE common.address ADD CONSTRAINT chk_address_state CHECK (state ~ '^[[:upper:]][[:lower:]]+(?:(\s|-)[[:alpha:]]+)*$');
 
-ALTER TABLE common.address ADD CONSTRAINT chk_address_country CHECK (country ~ '^[[:upper:]][[:lower:]]+(?:\s[[:upper:]][[:lower:]]+){0,1}$');
+ALTER TABLE common.address ADD CONSTRAINT chk_address_country CHECK (country ~ '^[[:upper:]][[:alpha:]\s''-]*(?<![\s-])$');
 
 ALTER TABLE users.user ADD CONSTRAINT chk_user_email CHECK (email ~ '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6}$');
 

--- a/Database/init-db.sql
+++ b/Database/init-db.sql
@@ -8,100 +8,100 @@ CREATE TYPE users.role AS ENUM ('User', 'Organizer', 'Admin');
 CREATE TYPE common.object_type AS ENUM ('Event', 'User');
 
 CREATE TABLE IF NOT EXISTS events.event (
- "id" SERIAL PRIMARY KEY,
- "name" text NOT NULL CONSTRAINT events_event_name_maxlength CHECK (LENGTH("name") <= 64),
- "address_id" integer NOT NULL,
- "description" text NOT NULL CONSTRAINT events_event_description_maxlength CHECK (LENGTH("description") <= 4048),
- "organizer_id" integer NOT NULL,
- "start_at" timestamptz NOT NULL,
- "end_at" timestamptz NOT NULL,
- "created_at" timestamptz NOT NULL,
- "updated_at" timestamptz NOT NULL,
- "slug" text NOT NULL CONSTRAINT events_event_slug_maxlength CHECK (LENGTH("slug") <= 128),
- "status" common.event_status NOT NULL
+    "id" SERIAL PRIMARY KEY,
+    "name" text NOT NULL CONSTRAINT events_event_name_maxlength CHECK (LENGTH("name") <= 64),
+    "address_id" integer NOT NULL,
+    "description" text NOT NULL CONSTRAINT events_event_description_maxlength CHECK (LENGTH("description") <= 4048),
+    "organizer_id" integer NOT NULL,
+    "start_at" timestamptz NOT NULL,
+    "end_at" timestamptz NOT NULL,
+    "created_at" timestamptz NOT NULL,
+    "updated_at" timestamptz NOT NULL,
+    "slug" text NOT NULL CONSTRAINT events_event_slug_maxlength CHECK (LENGTH("slug") <= 128),
+    "status" common.event_status NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS events.participant (
- "id" SERIAL PRIMARY KEY,
- "event_id" integer NOT NULL,
- "user_id" integer NOT NULL,
- "status" common.participant_status NOT NULL,
- UNIQUE ("event_id", "user_id")
+    "id" SERIAL PRIMARY KEY,
+    "event_id" integer NOT NULL,
+    "user_id" integer NOT NULL,
+    "status" common.participant_status NOT NULL,
+    UNIQUE ("event_id", "user_id")
 );
 
 CREATE TABLE IF NOT EXISTS events.tag (
- "id" SERIAL PRIMARY KEY,
- "name" text NOT NULL CONSTRAINT events_tag_name_maxlength CHECK (LENGTH("name") <= 64) UNIQUE
+    "id" SERIAL PRIMARY KEY,
+    "name" text NOT NULL CONSTRAINT events_tag_name_maxlength CHECK (LENGTH("name") <= 64) UNIQUE
 );
 
 CREATE TABLE IF NOT EXISTS events.event_tag (
- "event_id" integer NOT NULL,
- "tag_id" integer NOT NULL,
- PRIMARY KEY (event_id, tag_id) 
+    "event_id" integer NOT NULL,
+    "tag_id" integer NOT NULL,
+    PRIMARY KEY (event_id, tag_id) 
 );
 
 CREATE TABLE IF NOT EXISTS users.user (
- "id" SERIAL PRIMARY KEY,
- "name" text NOT NULL CONSTRAINT users_user_name_maxlength CHECK (LENGTH(name) <= 64),
- "surname" text NOT NULL CONSTRAINT users_user_surname_maxlength CHECK (LENGTH("surname") <= 64),
- "username" text NOT NULL CONSTRAINT users_user_username_maxlength CHECK (LENGTH("username") <= 64) UNIQUE,
- "password" text NOT NULL,
- "created_at" timestamptz NOT NULL,
- "updated_at" timestamptz NOT NULL,
- "role" users.role NOT NULL,
- "email" text NOT NULL CONSTRAINT users_user_email_maxlength CHECK (LENGTH("email") <= 255) UNIQUE,
- "is_active" boolean NOT NULL,
- "address_id" integer NOT NULL,
- "phone" text CONSTRAINT users_user_phone_maxlength CHECK (LENGTH("phone") <= 16) UNIQUE
+    "id" SERIAL PRIMARY KEY,
+    "name" text NOT NULL CONSTRAINT users_user_name_maxlength CHECK (LENGTH(name) <= 64),
+    "surname" text NOT NULL CONSTRAINT users_user_surname_maxlength CHECK (LENGTH("surname") <= 64),
+    "username" text NOT NULL CONSTRAINT users_user_username_maxlength CHECK (LENGTH("username") <= 64) UNIQUE,
+    "password" text NOT NULL,
+    "created_at" timestamptz NOT NULL,
+    "updated_at" timestamptz NOT NULL,
+    "role" users.role NOT NULL,
+    "email" text NOT NULL CONSTRAINT users_user_email_maxlength CHECK (LENGTH("email") <= 255) UNIQUE,
+    "is_active" boolean NOT NULL,
+    "address_id" integer NOT NULL,
+    "phone" text CONSTRAINT users_user_phone_maxlength CHECK (LENGTH("phone") <= 16) UNIQUE
 );
 
 CREATE TABLE IF NOT EXISTS events.parameter (
- "id" SERIAL PRIMARY KEY,
- "key" text NOT NULL CONSTRAINT events_patameter_key_maxlength CHECK (LENGTH("key") <= 32),
- "value" text NOT NULL CONSTRAINT events_patameter_value_maxlength CHECK (LENGTH("value") <= 64),
- UNIQUE("key", "value")
+    "id" SERIAL PRIMARY KEY,
+    "key" text NOT NULL CONSTRAINT events_patameter_key_maxlength CHECK (LENGTH("key") <= 32),
+    "value" text NOT NULL CONSTRAINT events_patameter_value_maxlength CHECK (LENGTH("value") <= 64),
+    UNIQUE("key", "value")
 );
 
 CREATE TABLE IF NOT EXISTS events.event_parameter (
- "parameter_id" integer NOT NULL,
- "event_id" integer NOT NULL,
- PRIMARY KEY (parameter_id, event_id)
+    "parameter_id" integer NOT NULL,
+    "event_id" integer NOT NULL,
+    PRIMARY KEY (parameter_id, event_id)
 );
 
 CREATE TABLE IF NOT EXISTS events.comment (
- "id" SERIAL PRIMARY KEY,
- "event_id" integer NOT NULL,
- "content" text NOT NULL CONSTRAINT events_comment_content_maxlength CHECK (LENGTH("content") <= 1024),
- "created_at" timestamptz NOT NULL,
- "user_id" integer NOT NULL
+    "id" SERIAL PRIMARY KEY,
+    "event_id" integer NOT NULL,
+    "content" text NOT NULL CONSTRAINT events_comment_content_maxlength CHECK (LENGTH("content") <= 1024),
+    "created_at" timestamptz NOT NULL,
+    "user_id" integer NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS common.address (
- "id" SERIAL PRIMARY KEY,
- "city" text NOT NULL CONSTRAINT common_address_city_maxlength CHECK (LENGTH("city") <= 64),
- "country" text NOT NULL CONSTRAINT common_address_country_maxlength CHECK (LENGTH("country") <= 64),
- "street" text NOT NULL CONSTRAINT common_address_street_maxlength CHECK (LENGTH("street") <= 64),
- "state" text NOT NULL CONSTRAINT common_address_state_maxlength CHECK (LENGTH("state") <= 64),
- "zip_code" text CONSTRAINT common_address_zip_code_maxlength CHECK (LENGTH("zip_code") <= 8)
+    "id" SERIAL PRIMARY KEY,
+    "city" text NOT NULL CONSTRAINT common_address_city_maxlength CHECK (LENGTH("city") <= 64),
+    "country" text NOT NULL CONSTRAINT common_address_country_maxlength CHECK (LENGTH("country") <= 64),
+    "street" text NOT NULL CONSTRAINT common_address_street_maxlength CHECK (LENGTH("street") <= 64),
+    "state" text NOT NULL CONSTRAINT common_address_state_maxlength CHECK (LENGTH("state") <= 64),
+    "zip_code" text CONSTRAINT common_address_zip_code_maxlength CHECK (LENGTH("zip_code") <= 8)
 );
 
 CREATE TABLE IF NOT EXISTS common.image (
- "id" SERIAL PRIMARY KEY,
- "image_data" bytea NOT NULL,
- "object_type" common.object_type NOT NULL,
- "object_id" integer NOT NULL
+    "id" SERIAL PRIMARY KEY,
+    "image_data" bytea NOT NULL,
+    "object_type" common.object_type NOT NULL,
+    "object_id" integer NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS users.user_interest (
- "user_id" integer NOT NULL,
- "interest_id" integer NOT NULL,
- "level" integer NOT NULL,
- PRIMARY KEY (user_id, interest_id)
+    "user_id" integer NOT NULL,
+    "interest_id" integer NOT NULL,
+    "level" integer NOT NULL,
+    PRIMARY KEY (user_id, interest_id)
 );
 
 CREATE TABLE IF NOT EXISTS users.interest (
- "id" SERIAL PRIMARY KEY,
- "name" text NOT NULL CONSTRAINT users_interest_name_maxlength CHECK (LENGTH("name") <= 32) UNIQUE
+    "id" SERIAL PRIMARY KEY,
+    "name" text NOT NULL CONSTRAINT users_interest_name_maxlength CHECK (LENGTH("name") <= 32) UNIQUE
 );
 
 ALTER TABLE events.event ADD FOREIGN KEY ("address_id") REFERENCES common.address ("id");

--- a/Database/init-db.sql
+++ b/Database/init-db.sql
@@ -8,100 +8,100 @@ CREATE TYPE users.role AS ENUM ('User', 'Organizer', 'Admin');
 CREATE TYPE common.object_type AS ENUM ('Event', 'User');
 
 CREATE TABLE IF NOT EXISTS events.event (
-  "id" SERIAL PRIMARY KEY,
-  "name" text NOT NULL CONSTRAINT events_event_name_maxlength CHECK (LENGTH("name") <= 64),
-  "address_id" integer NOT NULL,
-  "description" text NOT NULL CONSTRAINT events_event_description_maxlength CHECK (LENGTH("description") <= 4048),
-  "organizer_id" integer NOT NULL,
-  "start_at" timestamptz NOT NULL,
-  "end_at" timestamptz NOT NULL,
-  "created_at" timestamptz NOT NULL,
-  "updated_at" timestamptz NOT NULL,
-  "slug" text NOT NULL CONSTRAINT events_event_slug_maxlength CHECK (LENGTH("slug") <= 128),
-  "status" common.event_status NOT NULL
+ "id" SERIAL PRIMARY KEY,
+ "name" text NOT NULL CONSTRAINT events_event_name_maxlength CHECK (LENGTH("name") <= 64),
+ "address_id" integer NOT NULL,
+ "description" text NOT NULL CONSTRAINT events_event_description_maxlength CHECK (LENGTH("description") <= 4048),
+ "organizer_id" integer NOT NULL,
+ "start_at" timestamptz NOT NULL,
+ "end_at" timestamptz NOT NULL,
+ "created_at" timestamptz NOT NULL,
+ "updated_at" timestamptz NOT NULL,
+ "slug" text NOT NULL CONSTRAINT events_event_slug_maxlength CHECK (LENGTH("slug") <= 128),
+ "status" common.event_status NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS events.participant (
-  "id" SERIAL PRIMARY KEY,
-  "event_id" integer NOT NULL,
-  "user_id" integer NOT NULL,
-  "status" common.participant_status NOT NULL,
-  UNIQUE ("event_id", "user_id")
+ "id" SERIAL PRIMARY KEY,
+ "event_id" integer NOT NULL,
+ "user_id" integer NOT NULL,
+ "status" common.participant_status NOT NULL,
+ UNIQUE ("event_id", "user_id")
 );
 
 CREATE TABLE IF NOT EXISTS events.tag (
-  "id" SERIAL PRIMARY KEY,
-  "name" text NOT NULL CONSTRAINT events_tag_name_maxlength CHECK (LENGTH("name") <= 64) UNIQUE
+ "id" SERIAL PRIMARY KEY,
+ "name" text NOT NULL CONSTRAINT events_tag_name_maxlength CHECK (LENGTH("name") <= 64) UNIQUE
 );
 
 CREATE TABLE IF NOT EXISTS events.event_tag (
-  "event_id" integer NOT NULL,
-  "tag_id" integer NOT NULL,
-  PRIMARY KEY (event_id, tag_id) 
+ "event_id" integer NOT NULL,
+ "tag_id" integer NOT NULL,
+ PRIMARY KEY (event_id, tag_id) 
 );
 
 CREATE TABLE IF NOT EXISTS users.user (
-  "id" SERIAL PRIMARY KEY,
-  "name" text NOT NULL CONSTRAINT users_user_name_maxlength CHECK (LENGTH(name) <= 64),
-  "surname" text NOT NULL  CONSTRAINT users_user_surname_maxlength CHECK (LENGTH("surname") <= 64),
-  "username" text NOT NULL  CONSTRAINT users_user_username_maxlength CHECK (LENGTH("username") <= 64) UNIQUE,
-  "password" text NOT NULL,
-  "created_at" timestamptz NOT NULL,
-  "updated_at" timestamptz NOT NULL,
-  "role" users.role NOT NULL,
-  "email" text NOT NULL  CONSTRAINT users_user_email_maxlength CHECK (LENGTH("email") <= 255) UNIQUE,
-  "is_active" boolean NOT NULL,
-  "address_id" integer NOT NULL,
-  "phone" text  CONSTRAINT users_user_phone_maxlength CHECK (LENGTH("phone") <= 16) UNIQUE
+ "id" SERIAL PRIMARY KEY,
+ "name" text NOT NULL CONSTRAINT users_user_name_maxlength CHECK (LENGTH(name) <= 64),
+ "surname" text NOT NULL CONSTRAINT users_user_surname_maxlength CHECK (LENGTH("surname") <= 64),
+ "username" text NOT NULL CONSTRAINT users_user_username_maxlength CHECK (LENGTH("username") <= 64) UNIQUE,
+ "password" text NOT NULL,
+ "created_at" timestamptz NOT NULL,
+ "updated_at" timestamptz NOT NULL,
+ "role" users.role NOT NULL,
+ "email" text NOT NULL CONSTRAINT users_user_email_maxlength CHECK (LENGTH("email") <= 255) UNIQUE,
+ "is_active" boolean NOT NULL,
+ "address_id" integer NOT NULL,
+ "phone" text CONSTRAINT users_user_phone_maxlength CHECK (LENGTH("phone") <= 16) UNIQUE
 );
 
 CREATE TABLE IF NOT EXISTS events.parameter (
-  "id" SERIAL PRIMARY KEY,
-  "key" text NOT NULL CONSTRAINT events_patameter_key_maxlength CHECK (LENGTH("key") <= 32),
-  "value" text NOT NULL CONSTRAINT events_patameter_value_maxlength CHECK (LENGTH("value") <= 64),
-  UNIQUE("key", "value")
+ "id" SERIAL PRIMARY KEY,
+ "key" text NOT NULL CONSTRAINT events_patameter_key_maxlength CHECK (LENGTH("key") <= 32),
+ "value" text NOT NULL CONSTRAINT events_patameter_value_maxlength CHECK (LENGTH("value") <= 64),
+ UNIQUE("key", "value")
 );
 
 CREATE TABLE IF NOT EXISTS events.event_parameter (
-  "parameter_id" integer NOT NULL,
-  "event_id" integer NOT NULL,
-  PRIMARY KEY (parameter_id, event_id)
+ "parameter_id" integer NOT NULL,
+ "event_id" integer NOT NULL,
+ PRIMARY KEY (parameter_id, event_id)
 );
 
 CREATE TABLE IF NOT EXISTS events.comment (
-  "id" SERIAL PRIMARY KEY,
-  "event_id" integer NOT NULL,
-  "content" text NOT NULL CONSTRAINT events_comment_content_maxlength CHECK (LENGTH("content") <= 1024),
-  "created_at" timestamptz NOT NULL,
-  "user_id" integer NOT NULL
+ "id" SERIAL PRIMARY KEY,
+ "event_id" integer NOT NULL,
+ "content" text NOT NULL CONSTRAINT events_comment_content_maxlength CHECK (LENGTH("content") <= 1024),
+ "created_at" timestamptz NOT NULL,
+ "user_id" integer NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS common.address (
-  "id" SERIAL PRIMARY KEY,
-  "city" text NOT NULL CONSTRAINT common_address_city_maxlength CHECK (LENGTH("city") <= 64),
-  "country" text NOT NULL CONSTRAINT common_address_country_maxlength CHECK (LENGTH("country") <= 64),
-  "street" text NOT NULL CONSTRAINT common_address_street_maxlength CHECK (LENGTH("street") <= 64),
-  "state" text NOT NULL CONSTRAINT common_address_state_maxlength CHECK (LENGTH("state") <= 64),
-  "zip_code" text CONSTRAINT common_address_zip_code_maxlength CHECK (LENGTH("zip_code") <= 8)
+ "id" SERIAL PRIMARY KEY,
+ "city" text NOT NULL CONSTRAINT common_address_city_maxlength CHECK (LENGTH("city") <= 64),
+ "country" text NOT NULL CONSTRAINT common_address_country_maxlength CHECK (LENGTH("country") <= 64),
+ "street" text NOT NULL CONSTRAINT common_address_street_maxlength CHECK (LENGTH("street") <= 64),
+ "state" text NOT NULL CONSTRAINT common_address_state_maxlength CHECK (LENGTH("state") <= 64),
+ "zip_code" text CONSTRAINT common_address_zip_code_maxlength CHECK (LENGTH("zip_code") <= 8)
 );
 
 CREATE TABLE IF NOT EXISTS common.image (
-  "id" SERIAL PRIMARY KEY,
-  "image_data" bytea NOT NULL,
-  "object_type" common.object_type NOT NULL,
-  "object_id" integer  NOT NULL
+ "id" SERIAL PRIMARY KEY,
+ "image_data" bytea NOT NULL,
+ "object_type" common.object_type NOT NULL,
+ "object_id" integer NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS users.user_interest (
-  "user_id" integer NOT NULL,
-  "interest_id" integer NOT NULL,
-  "level" integer NOT NULL,
-  PRIMARY KEY (user_id, interest_id)
+ "user_id" integer NOT NULL,
+ "interest_id" integer NOT NULL,
+ "level" integer NOT NULL,
+ PRIMARY KEY (user_id, interest_id)
 );
 
 CREATE TABLE IF NOT EXISTS users.interest (
-  "id" SERIAL PRIMARY KEY,
-  "name" text NOT NULL CONSTRAINT users_interest_name_maxlength CHECK (LENGTH("name") <= 32) UNIQUE
+ "id" SERIAL PRIMARY KEY,
+ "name" text NOT NULL CONSTRAINT users_interest_name_maxlength CHECK (LENGTH("name") <= 32) UNIQUE
 );
 
 ALTER TABLE events.event ADD FOREIGN KEY ("address_id") REFERENCES common.address ("id");


### PR DESCRIPTION
## Description
Change regexes to match more correct formats - applies to `address.street`, `address.city`, `address.country`, `user.name`, `user.surname` and `user.username`.

Following screenshots confirming fixes:
`address.country`

![image](https://github.com/wzarek/Reasn/assets/61229912/3ef7d0f3-c985-4b31-ad5e-40c7f08460c8)


`address.street`

![image](https://github.com/wzarek/Reasn/assets/61229912/0f1a0ad4-0a38-4de2-a8f0-22b296dc2b12)


`address.city`

![image](https://github.com/wzarek/Reasn/assets/61229912/c9d4b171-8e28-41b8-87c3-2529c66c52f4)

`user.name`

![image](https://github.com/wzarek/Reasn/assets/61229912/1beda310-075e-4590-920d-506f70a3ba75)

`user.surname`

![image](https://github.com/wzarek/Reasn/assets/61229912/4951c998-9e16-4b01-af7a-a87baad53a23)

`user.username`

![image](https://github.com/wzarek/Reasn/assets/61229912/29528982-6e8f-4b21-89cf-1249decc9ccc)


## Related issue and/or ticket
Closes #26 [RSN-26](https://toopricey.youtrack.cloud/issue/RSN-26/bug-Regex-problem-with-Address-and-User-tables)
